### PR TITLE
Correctly show window/bitmap targets & show HW support & OpenWatcom

### DIFF
--- a/wglinfo.cpp
+++ b/wglinfo.cpp
@@ -526,6 +526,7 @@ public:
   //!   visual ~= pixel format descriptor
   //!   id      = pixel format number (integer from 1 - max pixel formats)
   //!   dep     = cColorBits      - color depth
+  //!   cl      = dwFlags & PFD_DRAW_TO_*  - render destination (window (wn), bitmap (bm), both (wb))
   //!   xsp     = no analog       - transparent pixel (currently always ".")
   //!   bfsz    = cColorBits      - framebuffer size (no analog in Win32?)
   //!   lvl     = bReserved       - overlay(>0), underlay(<0), main plane(0).
@@ -601,11 +602,13 @@ public:
       std::cout << "0x" << std::hex << std::setw(3) << std::setfill('0') << aFormatIter << std::dec << std::setfill(' ') << " ";
       std::cout << std::setw(2) << (int)aFormat.cColorBits << " ";
 
-      std::cout << ((aFormat.dwFlags & PFD_DRAW_TO_WINDOW) != 0
+      std::cout << ((aFormat.dwFlags & (PFD_DRAW_TO_WINDOW | PFD_DRAW_TO_BITMAP)) == (PFD_DRAW_TO_WINDOW | PFD_DRAW_TO_BITMAP)
+                ? "wb "
+                : ((aFormat.dwFlags & PFD_DRAW_TO_WINDOW) != 0
                  ? "wn "
                  :  ((aFormat.dwFlags & PFD_DRAW_TO_BITMAP) != 0
                   ? "bm "
-                  : ".  "));
+                  : ".  ")));
 
       std::cout << " . " << std::setw(2) << (int)aFormat.cColorBits << " ";
 

--- a/wglinfo.cpp
+++ b/wglinfo.cpp
@@ -9,6 +9,7 @@
 
 #include <windows.h>
 
+#include <string>
 #include <iomanip>
 #include <iostream>
 
@@ -579,7 +580,7 @@ public:
       if (theIsVerbose)
       {
         const char* aColorSpace = "";
-        if (aGetAttribIProc != nullptr)
+        if (aGetAttribIProc != NULL)
         {
           // fetch colorspace information using WGL_EXT_colorspace extension
           int aColorAttribs[1] = { WGL_COLORSPACE_EXT };
@@ -1183,7 +1184,7 @@ private:
 
 };
 
-int main (int theNbArgs, char** theArgVec)
+int actual_main (int theNbArgs, char** theArgVec)
 {
   bool isVerbose = false, toPrintVisuals = true, toShowEgl = true;
   for (int anArgIter = 1; anArgIter < theNbArgs; ++anArgIter)
@@ -1211,7 +1212,7 @@ int main (int theNbArgs, char** theArgVec)
     {
       std::cerr << "Syntax error! Unknown argument '" << theArgVec[anArgIter] << "'\n\n";
       char* anArgs[2] = { theArgVec[0], "-h" };
-      main (2, anArgs);
+      actual_main (2, anArgs);
       return 1;
     }
   }
@@ -1249,4 +1250,9 @@ int main (int theNbArgs, char** theArgVec)
   }
 
   return 0;
+}
+
+int main(int argc, char** argv)
+{
+  return actual_main(argc, argv);
 }

--- a/wglinfo.cpp
+++ b/wglinfo.cpp
@@ -593,6 +593,14 @@ public:
                         : ", Unknown");
           }
         }
+        const char* rendertarget;
+        if ((aFormat.dwFlags & (PFD_DRAW_TO_WINDOW | PFD_DRAW_TO_BITMAP)) == (PFD_DRAW_TO_WINDOW | PFD_DRAW_TO_BITMAP))
+            rendertarget = "window/bitmap";
+        else if ((aFormat.dwFlags & PFD_DRAW_TO_WINDOW) != 0)
+            rendertarget = "window";
+        else
+            rendertarget = "bitmap";
+
         std::cout << "Visual ID: " << aFormatIter << "\n"
                   << "    color: R" << int(aFormat.cRedBits) << "G" << int(aFormat.cGreenBits) << "B" << int(aFormat.cBlueBits) << "A" << int(aFormat.cAlphaBits)
                                     << " (" << getColorBufferClass (aFormat.cColorBits, aFormat.cRedBits) << ", " << int(aFormat.cColorBits)
@@ -604,7 +612,7 @@ public:
                                    << " level: " << int(aFormat.bReserved) << "\n"
                   << "    auxBuffers: " << int(aFormat.cAuxBuffers)
                                         << " accum: R" << int(aFormat.cAccumRedBits) << "G" << int(aFormat.cAccumGreenBits) << "B" << int(aFormat.cAccumBlueBits) << "A" << int(aFormat.cAccumAlphaBits)<< "\n"
-                  << "    target: " << rendertarget << "\n";
+                  << "    renderer: " << renderer << " target: " << rendertarget << "\n";
         continue;
       }
 

--- a/wglinfo.cpp
+++ b/wglinfo.cpp
@@ -545,6 +545,10 @@ public:
   //!   accum b = cAccumBlueBits  - # bits of blue in accumulation buffer
   //!   accum a = cAccumAlphaBits - # bits of alpha in accumulation buffer
   //!   ms      = no analog  - multisample buffers
+  //!   rdr     = dwFlags & (PFD_GENERIC_FORMAT | PFD_GENERIC_ACCELERATED)
+  //!                             - renderer (gdi (software only),
+  //!                                         mcd (mini-icd cooperating with generic driver),
+  //!                                         icd (standalone driver))
   void PrintVisualInfoWgl (bool theIsVerbose)
   {
     wglGetPixelFormatAttribivARB_t aGetAttribIProc = (wglGetPixelFormatAttribivARB_t )wglGetProcAddress ("wglGetPixelFormatAttribivARB");
@@ -555,8 +559,8 @@ public:
     if (!theIsVerbose)
     {
       std::cout << "    visual  x  bf lv rg d st  r  g  b a  ax dp st accum buffs  ms \n";
-      std::cout <<"  id dep cl sp sz l  ci b ro sz sz sz sz bf th cl  r  g  b  a ns b\n";
-      std::cout <<"------------------------------------------------------------------\n";
+      std::cout <<"  id dep cl sp sz l  ci b ro sz sz sz sz bf th cl  r  g  b  a ns b rdr\n";
+      std::cout <<"----------------------------------------------------------------------\n";
     }
     for (int aFormatIter = 1; aFormatIter <= aNbFormats; ++aFormatIter)
     {
@@ -567,6 +571,10 @@ public:
       {
         continue;
       }
+      const char* renderer;
+      if ((aFormat.dwFlags & PFD_GENERIC_FORMAT) == 0)            renderer = "icd";
+      else if ((aFormat.dwFlags & PFD_GENERIC_ACCELERATED) != 0)  renderer = "mcd";
+      else                                                        renderer = "gdi";
 
       if (theIsVerbose)
       {
@@ -595,7 +603,8 @@ public:
                                    << " renderType: " << (aFormat.iPixelType == PFD_TYPE_RGBA ? "rgba" : "palette")
                                    << " level: " << int(aFormat.bReserved) << "\n"
                   << "    auxBuffers: " << int(aFormat.cAuxBuffers)
-                                        << " accum: R" << int(aFormat.cAccumRedBits) << "G" << int(aFormat.cAccumGreenBits) << "B" << int(aFormat.cAccumBlueBits) << "A" << int(aFormat.cAccumAlphaBits)<< "\n";
+                                        << " accum: R" << int(aFormat.cAccumRedBits) << "G" << int(aFormat.cAccumGreenBits) << "B" << int(aFormat.cAccumBlueBits) << "A" << int(aFormat.cAccumAlphaBits)<< "\n"
+                  << "    target: " << rendertarget << "\n";
         continue;
       }
 
@@ -631,16 +640,16 @@ public:
       printInt2d (aFormat.cAccumBlueBits  ? (int)aFormat.cAccumBlueBits : -1);
       printInt2d (aFormat.cAccumAlphaBits ? (int)aFormat.cAccumAlphaBits : -1);
 
-      std::cout <<" . .\n";
+      std::cout <<" . . " << renderer << "\n";
     }
 
     // table footer
     if (!theIsVerbose)
     {
-      std::cout << "------------------------------------------------------------------\n";
-      std::cout << "    visual  x  bf lv rg d st  r  g  b a  ax dp st accum buffs  ms \n";
+      std::cout << "----------------------------------------------------------------------\n";
+      std::cout << "    visual  x  bf lv rg d st  r  g  b a  ax dp st accum buffs  ms  rdr\n";
       std::cout << "  id dep cl sp sz l  ci b ro sz sz sz sz bf th cl  r  g  b  a ns b\n";
-      std::cout << "------------------------------------------------------------------\n\n";
+      std::cout << "----------------------------------------------------------------------\n\n";
     }
   }
 


### PR DESCRIPTION
I used wglinfo to troubleshoot why the OpenGL screensavers in Windows 2000 were not getting hardware acceleration on a Matrox G450 card. It turned out that the most crucial information, the type of acceleration, was not yet displayed by wglinfo. At the same time, I noticed that rendering to windows and rendering to bitmaps is not exclusive, so I added a new target type. Finally, to make the software actually run in Windows 2000, I compiled it with OpenWatcom 1.9, and needed to slightly adjust the C++ code.
While this is multiple features in one PR, the Watcom stuff is in a separate commit and can be omitted or I can re-author the PR excluding it.